### PR TITLE
Add candidate and committee ranks

### DIFF
--- a/templates/camp_fin/candidate-list.html
+++ b/templates/camp_fin/candidate-list.html
@@ -13,6 +13,7 @@
             <table class="table table-striped" id="candidate-list">
                 <thead>
                     <tr>
+                        <th>Rank</th>
                         <th>
                             <a href="{% url 'candidate-list' %}?{% query_transform request order_by='last_name' sort_order=toggle_order %}">
                                 Candidate
@@ -51,6 +52,7 @@
                 <tbody>
                     {% for candidate in object_list %}
                         <tr>
+                            <td>{{ candidate.rank }}</td>
                             <td>
                                 <a href="{% url 'candidate-detail' candidate.slug %}">
                                     {% spaceless %}

--- a/templates/camp_fin/committee-list.html
+++ b/templates/camp_fin/committee-list.html
@@ -13,6 +13,7 @@
             <table class="table table-striped" id="committee-list">
                 <thead>
                     <tr>
+                        <th>Rank</th>
                         <th>
                             <a href="{% url 'committee-list' %}?{% query_transform request order_by='name' sort_order=toggle_order %}">
                                 Committee
@@ -42,6 +43,7 @@
                 <tbody>
                     {% for committee in object_list %}
                         <tr>
+                            <td>{{ committee.rank }}</td>
                             <td>
                                 <a href="{% url 'committee-detail' committee.slug %}">
                                     {{ committee.name }}


### PR DESCRIPTION
Closes #5 

I just ended up using a window function to calculate this on the fly. It's a bit easier than maintaining a materialized view or something. The one caveat that I ran into, however (and I'd like to get your input on this @derekeder) is the particular window function I am using (`rank`) does kind of a weird thing when it comes to ties. There are a ton of people that are tied at 752 place (because they all have $0) but the next place after that is 2957th:

![screenshot from 2016-09-07 11 14 28](https://cloud.githubusercontent.com/assets/551491/18319755/bd253134-74ec-11e6-832e-46267f24e520.png)

I'm guessing the difference there is just all the records that are tied for that place. The other option that I was looking at was using the `row_number` window function which basically just numbers the rows (but doesn't do anything smart with ties).

Anyways, any preference? I prefer the way `rank` handles it but I  don't really like the way it leaves the giant gap. Maybe @fgregg knows a way to make it not behave that way?