### PR TITLE
Lock filings during transaction import, address duplicates in candidate and filing import

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,4 @@ exclude =
 # So flake8 plays nicely with black
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html
 max-line-length = 120
-extend-ignore = E203
+extend-ignore = E203 E231

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -18,7 +18,7 @@ jobs:
           import json
           from datetime import date
           current_year = date.today().year
-          print(json.dumps(list(current_year - 2, current_year + 1))))
+          print(json.dumps(list(current_year - 1, current_year + 1))))
           ")" >> $GITHUB_OUTPUT
 
   import_filings:

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -6,6 +6,21 @@ on:
     types: [nightly-scrape-done]
 
 jobs:
+  generate_years_array:
+    runs-on: ubuntu-latest
+    outputs:
+      years: ${{ steps.set_years.outputs.years }}
+    steps:
+      - name: Generate year range
+        id: set_years
+        run: |
+          echo "years=$(python3 -c "
+          import json
+          from datetime import date
+          current_year = date.today().year
+          print(json.dumps(list(current_year - 2, current_year + 1))))
+          ")" >> $GITHUB_OUTPUT
+
   import_filings:
     runs-on: ubuntu-latest
 
@@ -25,13 +40,13 @@ jobs:
 
   import_transactions:
     runs-on: ubuntu-latest
-    needs: import_filings
+    needs: [generate_years_array, import_filings]
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 3
       matrix:
         transaction_type: [CON, EXP]
-        year: [2024, 2025, 2026]
+        year: ${{ fromJson(needs.generate_years_array.outputs.years) }}
         month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "deploy"
+          ref: ${{ github.ref }}
       - name: Import candidate, PAC, and filing data
         run: |
           touch .env
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: "deploy"
+          ref: ${{ github.ref }}
       - name: Import transaction data
         run: |
           touch .env

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -30,8 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         transaction_type: [CON, EXP]
-        year: [2024, 2025]
-        quarter: [1, 2, 3, 4]
+        year: [2024, 2025, 2026]
+        month: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
       - uses: actions/checkout@v3
@@ -45,4 +45,4 @@ jobs:
             -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             -e DATABASE_URL=${{ secrets.DATABASE_URL }} \
-            app make import/${{ matrix.transaction_type }}_${{ matrix.quarter }}_${{ matrix.year }}
+            app make import/${{ matrix.transaction_type }}_${{ matrix.month }}_${{ matrix.year }}

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -14,18 +14,7 @@ jobs:
       - name: Generate year range
         id: set_years
         run: |
-          echo "years=$(
-            python3 -c "
-              import json
-              from datetime import date
-              current_year = date.today().year
-              print(
-                json.dumps(
-                  [current_year - 1, current_year]
-                )
-              )
-            "
-          )" >> $GITHUB_OUTPUT
+          echo "years=$(python3 -c "import json; from datetime import date; y = date.today().year; print(json.dumps([y - 1, y]))")" >> $GITHUB_OUTPUT
 
   import_filings:
     runs-on: ubuntu-latest

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -28,6 +28,7 @@ jobs:
     needs: import_filings
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         transaction_type: [CON, EXP]
         year: [2024, 2025, 2026]

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -14,12 +14,18 @@ jobs:
       - name: Generate year range
         id: set_years
         run: |
-          echo "years=$(python3 -c "
-          import json
-          from datetime import date
-          current_year = date.today().year
-          print(json.dumps(list(current_year - 1, current_year + 1))))
-          ")" >> $GITHUB_OUTPUT
+          echo "years=$(
+            python3 -c "
+              import json
+              from datetime import date
+              current_year = date.today().year
+              print(
+                json.dumps(
+                  [current_year - 1, current_year]
+                )
+              )
+            "
+          )" >> $GITHUB_OUTPUT
 
   import_filings:
     runs-on: ubuntu-latest

--- a/.github/workflows/etl.yml
+++ b/.github/workflows/etl.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: import_filings
     strategy:
+      fail-fast: false
       matrix:
         transaction_type: [CON, EXP]
         year: [2024, 2025]

--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,24 @@ THIS_YEAR=$(shell date +"%Y")
 NIGHTLY_YEARS=$(shell seq 2024 $(THIS_YEAR))
 QUARTERLY_YEARS=$(shell seq 2020 $(THIS_YEAR))
 
-define quarterly_target
-	$(foreach YEAR,$(1),$(patsubst %,import/$(2)_%_$(YEAR),1 2 3 4))
+define monthly_target
+	$(foreach YEAR,$(1),$(patsubst %,import/$(2)_%_$(YEAR),1 2 3 4 5 6 7 8 9 10 11 12))
 endef
 
 .PHONY : quarterly
 quarterly: import/candidates import/pacs import/candidate_filings import/pac_filings \
-	$(call quarterly_target,$(QUARTERLY_YEARS),CON) $(call quarterly_target,$(QUARTERLY_YEARS),EXP)
+	$(call monthly_target,$(QUARTERLY_YEARS),CON) $(call monthly_target,$(QUARTERLY_YEARS),EXP)
 	python manage.py make_search_index
 
 .PHONY : nightly
 nightly: import/candidates import/pacs import/candidate_filings import/pac_filings \
-	$(call quarterly_target,$(NIGHTLY_YEARS),CON) $(call quarterly_target,$(NIGHTLY_YEARS),EXP)
+	$(call monthly_target,$(NIGHTLY_YEARS),CON) $(call monthly_target,$(NIGHTLY_YEARS),EXP)
 	python manage.py make_search_index
 
 .SECONDEXPANSION:
 import/% : _data/sorted/$$(word 1, $$(subst _, , $$*))_$$(word 3, $$(subst _, , $$*)).csv
 	python manage.py import_transactions --transaction-type $(word 1, $(subst _, , $*)) \
-		--quarters $(word 2, $(subst _, , $*)) \
+		--months $(word 2, $(subst _, , $*)) \
 		--year $(word 3, $(subst _, , $*)) \
 		--file $<
 

--- a/camp_fin/management/commands/import_candidate_filings.py
+++ b/camp_fin/management/commands/import_candidate_filings.py
@@ -41,7 +41,7 @@ class Command(FilingCommand, BaseCommand):
             .get()
         )
 
-        url = f"https://login.cfis.sos.state.nm.us//ReportsOutput//{record['ReportFileName']}"
+        url = f"https://login.cfis.sos.state.nm.us//ReportsOutput//{record['ReportFileName']}"  # noqa
         final = record["Amended"] == "0" or None
 
         filing = models.Filing.objects.create(
@@ -55,18 +55,26 @@ class Command(FilingCommand, BaseCommand):
             report_version_id=record["ReportVersionID"],
         )
 
+        campaign = models.Campaign.objects.filter(
+            election_season__year=re.match(r"\d{4}", record["ElectionYear"]).group(0),
+            candidate__entity=entity,
+            office__description=record["OfficeName"],
+            district__name=record["District"],
+            county__name=record["Jurisdiction"] or None,
+        )
+
         try:
-            campaign = models.Campaign.objects.get(
-                election_season__year=re.match(r"\d{4}", record["ElectionYear"]).group(
-                    0
-                ),
-                candidate__entity=entity,
-                office__description=record["OfficeName"],
-                district__name=record["District"],
-                county__name=record["Jurisdiction"] or None,
-            )
+            campaign = campaign.get()
+
         except models.Campaign.DoesNotExist:
             pass
+
+        except models.Campaign.MultipleObjectsReturned:
+            self.stderr.write(
+                f"Found multiple matching campaigns for record {record}: {[c.__dict__ for c in campaign]}"
+            )
+            campaign = campaign.first()
+
         else:
             filing.campaign = campaign
             filing.save()

--- a/camp_fin/management/commands/import_candidate_filings.py
+++ b/camp_fin/management/commands/import_candidate_filings.py
@@ -41,7 +41,10 @@ class Command(FilingCommand, BaseCommand):
             .get()
         )
 
-        url = f"https://login.cfis.sos.state.nm.us//ReportsOutput//{record['ReportFileName']}"  # noqa
+        url = (
+            "https://login.cfis.sos.state.nm.us//ReportsOutput//"
+            + record["ReportFileName"]
+        )
         final = record["Amended"] == "0" or None
 
         filing = models.Filing.objects.create(

--- a/camp_fin/management/commands/import_candidates.py
+++ b/camp_fin/management/commands/import_candidates.py
@@ -130,7 +130,17 @@ class Command(BaseCommand):
                     except models.Candidate.MultipleObjectsReturned:
                         # If there are multiple matches, prefer the candidate explicitly
                         # linked to the PAC
-                        candidate = candidate.get(campaign__in=pac.campaigns.only("id"))
+                        try:
+                            candidate = candidate.get(
+                                campaign__in=pac.campaigns.only("id")
+                            )
+                        except (
+                            models.Candidate.DoesNotExist,
+                            models.Candidate.MultipleObjectsReturned,
+                        ):
+                            candidate = candidate.filter(
+                                campaign__in=pac.campaigns.only("id")
+                            ).first()
                         candidates_linked += 1
 
                     campaign = models.Campaign.objects.create(

--- a/camp_fin/management/commands/import_candidates.py
+++ b/camp_fin/management/commands/import_candidates.py
@@ -96,19 +96,19 @@ class Command(BaseCommand):
                         political_party=political_party,
                     )
                 except models.Campaign.DoesNotExist:
-                    try:
-                        candidate = (
-                            models.Candidate.objects.filter(
-                                Q(campaign__in=pac.campaigns.all())
-                                | Q(
-                                    email__iexact=record["CandidateEmail"],
-                                    business_phone=record["PublicPhoneNumber"],
-                                )
-                            )
-                            .distinct()
-                            .get()
+                    candidate = models.Candidate.objects.filter(
+                        Q(campaign__in=pac.campaigns.all())
+                        | Q(
+                            email__iexact=record["CandidateEmail"],
+                            business_phone=record["PublicPhoneNumber"],
                         )
+                    ).distinct()
+
+                    try:
+                        # If there's only one result, take it
+                        candidate = candidate.get()
                         candidates_linked += 1
+
                     except models.Candidate.DoesNotExist:
                         candidate_type, _ = models.EntityType.objects.get_or_create(
                             description="Candidate"
@@ -126,6 +126,12 @@ class Command(BaseCommand):
                         )
 
                         candidates_created += 1
+
+                    except models.Candidate.MultipleObjectsReturned:
+                        # If there are multiple matches, prefer the candidate explicitly
+                        # linked to the PAC
+                        candidate = candidate.get(campaign__in=pac.campaigns.only("id"))
+                        candidates_linked += 1
 
                     campaign = models.Campaign.objects.create(
                         election_season=election_season,

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -52,6 +52,16 @@ class Command(BaseCommand):
         Data will be retrieved from S3 unless a local CSV is specified as --file
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cache = {}
+
+    def _cached_get_or_create(self, model, **kwargs):
+        key = (model, tuple(sorted(kwargs.items())))
+        if key not in self._cache:
+            self._cache[key], _ = model.objects.get_or_create(**kwargs)
+        return self._cache[key]
+
     def add_arguments(self, parser):
         parser.add_argument(
             "--transaction-type",
@@ -275,11 +285,12 @@ class Command(BaseCommand):
         )
 
     def make_contributor(self, record):
-        state, _ = models.State.objects.get_or_create(
-            postal_code=record["Contributor State"]
+        state = self._cached_get_or_create(
+            models.State, postal_code=record["Contributor State"]
         )
 
-        address, _ = models.Address.objects.get_or_create(
+        address = self._cached_get_or_create(
+            models.Address,
             street=(
                 f"{record['Contributor Address Line 1']}"
                 f"{' ' + record['Contributor Address Line 2'] if record['Contributor Address Line 2'] else ''}"
@@ -289,8 +300,8 @@ class Command(BaseCommand):
             zipcode=record["Contributor Zip Code"],
         )
 
-        contact_type, _ = models.ContactType.objects.get_or_create(
-            description=record["Contributor Code"]
+        contact_type = self._cached_get_or_create(
+            models.ContactType, description=record["Contributor Code"]
         )
 
         full_name = re.sub(
@@ -332,8 +343,8 @@ class Command(BaseCommand):
                 contact_type=contact_type,
             )
         except models.Contact.DoesNotExist:
-            entity_type, _ = models.EntityType.objects.get_or_create(
-                description=record["Contributor Code"][:24]
+            entity_type = self._cached_get_or_create(
+                models.EntityType, description=record["Contributor Code"][:24]
             )
 
             entity = models.Entity.objects.create(
@@ -432,8 +443,8 @@ class Command(BaseCommand):
             )
 
             if record["Contribution Type"] == "Loans Received":
-                transaction_type, _ = models.LoanTransactionType.objects.get_or_create(
-                    description="Payment"
+                transaction_type = self._cached_get_or_create(
+                    models.LoanTransactionType, description="Payment"
                 )
 
                 loan, _ = models.Loan.objects.get_or_create(
@@ -482,7 +493,8 @@ class Command(BaseCommand):
                 else:
                     description = "Monetary Contribution"
 
-                transaction_type, _ = models.TransactionType.objects.get_or_create(
+                transaction_type = self._cached_get_or_create(
+                    models.TransactionType,
                     description=description,
                     contribution=True,
                     anonymous="anonymous" in record["Contribution Type"].lower(),
@@ -518,7 +530,8 @@ class Command(BaseCommand):
                 zipcode=record["Payee Zip Code"],
             )
 
-            transaction_type, _ = models.TransactionType.objects.get_or_create(
+            transaction_type = self._cached_get_or_create(
+                models.TransactionType,
                 description="Monetary Expenditure",
                 contribution=False,
                 anonymous=False,
@@ -559,13 +572,17 @@ class Command(BaseCommand):
     def total_filings(self, quarters, year):
         start, end = get_month_range(quarters)
 
-        for filing in tqdm(
-            models.Filing.objects.filter(
-                final=True,
-                filing_period__initial_date__month__gte=start,
-                filing_period__initial_date__month__lte=end,
-            ).iterator()
-        ):
+        filings = list(
+            tqdm(
+                models.Filing.objects.filter(
+                    final=True,
+                    filing_period__initial_date__month__gte=start,
+                    filing_period__initial_date__month__lte=end,
+                ).iterator()
+            )
+        )
+
+        for filing in filings:
             contributions = filing.contributions().aggregate(total=Sum("amount"))
             expenditures = filing.expenditures().aggregate(total=Sum("amount"))
             loans = filing.loans().aggregate(total=Sum("amount"))
@@ -574,4 +591,6 @@ class Command(BaseCommand):
             filing.total_expenditures = expenditures["total"] or 0
             filing.total_loans = loans["total"] or 0
 
-            filing.save()
+        models.Filing.objects.bulk_update(
+            filings, ["total_contributions", "total_expenditures", "total_loans"]
+        )

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -1,5 +1,4 @@
 import csv
-import math
 import re
 from itertools import groupby
 
@@ -23,25 +22,9 @@ def filing_key(record):
     )
 
 
-def get_quarter(date_str):
+def get_month(date_str):
     date = parse_date(date_str)
-    return math.ceil(date.month / 3.0)
-
-
-def get_month_range(quarters):
-    quarter_to_month_range = {
-        1: (1, 3),
-        2: (4, 6),
-        3: (7, 9),
-        4: (10, 12),
-    }
-
-    months = []
-
-    for q in quarters:
-        months.extend(quarter_to_month_range[q])
-
-    return min(months), max(months)
+    return date.month
 
 
 class Command(BaseCommand):
@@ -70,10 +53,10 @@ class Command(BaseCommand):
             help="Type of transaction to import: CON, EXP (Default: CON)",
         )
         parser.add_argument(
-            "--quarters",
-            dest="quarters",
-            default="1,2,3,4",
-            help="Comma-separated list of quarters to import (Default: 1,2,3,4)",
+            "--months",
+            dest="months",
+            default="1,2,3,4,5,6,7,8,9,10,11,12",
+            help="Comma-separated list of months to import (Default: 1,2,3,4,5,6,7,8,9,10,11,12)",
         )
         parser.add_argument(
             "--year",
@@ -104,45 +87,45 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Loading data from {transaction_type}_{year}.csv")
 
-        quarters = {int(q) for q in options["quarters"].split(",")}
-        quarter_string = ", ".join(f"Q{q}" for q in quarters)
+        months = {int(m) for m in options["months"].split(",")}
+        month_string = ", ".join(str(m) for m in sorted(months))
 
         with open(options["file"]) as f:
             self.stdout.write(
-                f"Importing transactions from filing periods beginning in {quarter_string}"
+                f"Importing transactions from filing periods beginning in months {month_string}"
             )
 
             if transaction_type == "CON":
-                self.import_contributions(f, quarters, year, options["batch_size"])
+                self.import_contributions(f, months, year, options["batch_size"])
 
             elif transaction_type == "EXP":
-                self.import_expenditures(f, quarters, year, options["batch_size"])
+                self.import_expenditures(f, months, year, options["batch_size"])
 
             self.stdout.write(self.style.SUCCESS("Transactions imported!"))
 
         self.stdout.write(
-            f"Totaling filings from periods beginning in {quarter_string}"
+            f"Totaling filings from periods beginning in months {month_string}"
         )
-        self.total_filings(quarters, year)
+        self.total_filings(months)
         self.stdout.write(self.style.SUCCESS("Filings totaled!"))
 
         call_command("aggregate_data")
 
-    def _records_by_filing(self, records, filing_quarters):
+    def _records_by_filing(self, records, filing_months):
         """
         Group records by filing, then filter for filings beginning in the specified
-        quarter/s. Note that, because transactions are organized by year, transactions
+        month/s. Note that, because transactions are organized by year, transactions
         for one filing can appear across two files, if the reporting period begins in
         one year and ends in the next. This approach will return filings beginning in
-        the specified quarter in *any* year, so that these split cases will be covered.
+        the specified month in *any* year, so that these split cases will be covered.
         For example, consider a filing period starting in December 2023 and ending in
         February 2024. Transactions would be split across the 2023 and 2024 files. To
-        get them all, you would run the Q4 import for both 2023 and 2024.
+        get them all, you would run the December import for both 2023 and 2024.
         """
-        records_in_quarters = filter(
-            lambda x: get_quarter(x["Start of Period"]) in filing_quarters, records
+        records_in_months = filter(
+            lambda x: get_month(x["Start of Period"]) in filing_months, records
         )
-        return groupby(tqdm(records_in_quarters), key=filing_key)
+        return groupby(tqdm(records_in_months), key=filing_key)
 
     def _save_batch(self, batch):
         """
@@ -154,13 +137,13 @@ class Command(BaseCommand):
         ):
             cls.objects.bulk_create(cls_records)
 
-    def import_contributions(self, f, quarters, year, batch_size):
+    def import_contributions(self, f, months, year, batch_size):
         reader = csv.DictReader(f)
 
         n_deleted = 0
         n_imported = 0
 
-        for _, records in self._records_by_filing(reader, quarters):
+        for _, records in self._records_by_filing(reader, months):
             batch = []
             filing = None
 
@@ -236,13 +219,13 @@ class Command(BaseCommand):
             )
         )
 
-    def import_expenditures(self, f, quarters, year, batch_size):
+    def import_expenditures(self, f, months, year, batch_size):
         reader = csv.DictReader(f)
 
         n_deleted = 0
         n_imported = 0
 
-        for _, records in self._records_by_filing(reader, quarters):
+        for _, records in self._records_by_filing(reader, months):
             batch = []
             filing = None
 
@@ -569,15 +552,13 @@ class Command(BaseCommand):
 
         return contribution
 
-    def total_filings(self, quarters, year):
-        start, end = get_month_range(quarters)
-
+    def total_filings(self, months):
         filings = list(
             tqdm(
                 models.Filing.objects.filter(
                     final=True,
-                    filing_period__initial_date__month__gte=start,
-                    filing_period__initial_date__month__lte=end,
+                    filing_period__initial_date__month__gte=min(months),
+                    filing_period__initial_date__month__lte=max(months),
                 ).iterator()
             )
         )

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -407,7 +407,8 @@ class Command(BaseCommand):
             )
             msg = (
                 f"{filings.count()} filings found for PAC {pac} from record "
-                f"{record}:\n{filing_meta}\n\nUsing most recent filing matching query..."  # noqa
+                f"{record}:\n{filing_meta}\n\n"
+                "Using most recent filing matching query..."
             )
             self.stderr.write(msg)
 

--- a/camp_fin/management/commands/import_transactions.py
+++ b/camp_fin/management/commands/import_transactions.py
@@ -5,6 +5,7 @@ from itertools import groupby
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+from django.db import transaction
 from django.db.models import Sum
 from tqdm import tqdm
 
@@ -145,67 +146,79 @@ class Command(BaseCommand):
 
     def import_contributions(self, f, quarters, year, batch_size):
         reader = csv.DictReader(f)
-        batch = []
 
         n_deleted = 0
         n_imported = 0
 
         for _, records in self._records_by_filing(reader, quarters):
-            for i, record in enumerate(records):
-                if i == 0:
-                    try:
-                        filing = self._get_filing(record)
-                    except ValueError:
-                        break
+            batch = []
+            filing = None
 
-                    # The contributions files are organized by the year
-                    # of the transaction date, not the date of the
-                    # filing, so transactions from the same filing can
-                    # appear in multiple contribution files.
-                    #
-                    # We need to make sure we just clear out the
-                    # contributions in a file that were purportedly made
-                    # in a given year.
-                    n_loans_deleted, _ = models.Loan.objects.filter(
-                        filing=filing, received_date__year=year
-                    ).delete()
-                    n_events_deleted, _ = models.SpecialEvent.objects.filter(
-                        filing=filing, event_date__year=year
-                    ).delete()
-                    n_transactions_deleted, _ = (
-                        models.Transaction.objects.filter(
-                            filing=filing, received_date__year=year
+            with transaction.atomic():
+                for i, record in enumerate(records):
+                    if i == 0:
+                        try:
+                            filing = self._get_filing(record)
+                        except ValueError:
+                            break
+
+                        filing = models.Filing.objects.select_for_update().get(
+                            id=filing.id
                         )
-                        .exclude(transaction_type__description="Monetary Expenditure")
-                        .delete()
-                    )
 
-                    n_deleted += (
-                        n_loans_deleted + n_events_deleted + n_transactions_deleted
-                    )
+                        # The contributions files are organized by the year
+                        # of the transaction date, not the date of the
+                        # filing, so transactions from the same filing can
+                        # appear in multiple contribution files.
+                        #
+                        # We need to make sure we just clear out the
+                        # contributions in a file that were purportedly made
+                        # in a given year.
+                        n_loans_deleted, _ = models.Loan.objects.filter(
+                            filing=filing, received_date__year=year
+                        ).delete()
+                        n_events_deleted, _ = models.SpecialEvent.objects.filter(
+                            filing=filing, event_date__year=year
+                        ).delete()
+                        n_transactions_deleted, _ = (
+                            models.Transaction.objects.filter(
+                                filing=filing, received_date__year=year
+                            )
+                            .exclude(
+                                transaction_type__description="Monetary Expenditure"
+                            )
+                            .delete()
+                        )
 
-                contributor = self.make_contributor(record)
+                        n_deleted += (
+                            n_loans_deleted + n_events_deleted + n_transactions_deleted
+                        )
 
-                if (
-                    record["Contribution Type"] in {"Loans Received", "Special Event"}
-                    or "Contribution" in record["Contribution Type"]
-                ):
-                    contribution = self.make_contribution(record, contributor, filing)
-                    batch.append(contribution)
+                    contributor = self.make_contributor(record)
 
-                else:
-                    self.stderr.write(
-                        f"Could not determine contribution type from record: {record['Contribution Type']}"
-                    )
+                    if (
+                        record["Contribution Type"]
+                        in {"Loans Received", "Special Event"}
+                        or "Contribution" in record["Contribution Type"]
+                    ):
+                        contribution = self.make_contribution(
+                            record, contributor, filing
+                        )
+                        batch.append(contribution)
 
-                if len(batch) % batch_size == 0:
+                    else:
+                        self.stderr.write(
+                            f"Could not determine contribution type from record: {record['Contribution Type']}"
+                        )
+
+                    if len(batch) % batch_size == 0 and batch:
+                        self._save_batch(batch)
+                        n_imported += len(batch)
+                        batch = []
+
+                if batch:
                     self._save_batch(batch)
-                    n_imported += batch_size
-                    batch = []
-
-        if len(batch) > 0:
-            self._save_batch(batch)
-            n_imported += len(batch)
+                    n_imported += len(batch)
 
         self.stdout.write(
             self.style.NOTICE(
@@ -215,38 +228,45 @@ class Command(BaseCommand):
 
     def import_expenditures(self, f, quarters, year, batch_size):
         reader = csv.DictReader(f)
-        batch = []
 
         n_deleted = 0
         n_imported = 0
 
         for _, records in self._records_by_filing(reader, quarters):
-            for i, record in enumerate(records):
-                if i == 0:
-                    try:
-                        filing = self._get_filing(record)
-                    except ValueError:
-                        break
+            batch = []
+            filing = None
 
-                    n_transactions, _ = models.Transaction.objects.filter(
-                        filing=filing,
-                        transaction_type__description="Monetary Expenditure",
-                        received_date__year=year,
-                    ).delete()
+            with transaction.atomic():
+                for i, record in enumerate(records):
+                    if i == 0:
+                        try:
+                            filing = self._get_filing(record)
+                        except ValueError:
+                            break
 
-                    n_deleted += n_transactions
+                        filing = models.Filing.objects.select_for_update().get(
+                            id=filing.id
+                        )
 
-                contribution = self.make_contribution(record, None, filing)
-                batch.append(contribution)
+                        n_transactions, _ = models.Transaction.objects.filter(
+                            filing=filing,
+                            transaction_type__description="Monetary Expenditure",
+                            received_date__year=year,
+                        ).delete()
 
-                if len(batch) % batch_size == 0:
+                        n_deleted += n_transactions
+
+                    contribution = self.make_contribution(record, None, filing)
+                    batch.append(contribution)
+
+                    if len(batch) % batch_size == 0 and batch:
+                        self._save_batch(batch)
+                        n_imported += len(batch)
+                        batch = []
+
+                if batch:
                     self._save_batch(batch)
-                    n_imported += batch_size
-                    batch = []
-
-        if len(batch) > 0:
-            self._save_batch(batch)
-            n_imported += len(batch)
+                    n_imported += len(batch)
 
         self.stdout.write(
             self.style.NOTICE(
@@ -393,7 +413,7 @@ class Command(BaseCommand):
             )
             msg = (
                 f"{filings.count()} filings found for PAC {pac} from record "
-                f"{record}:\n{filing_meta}\n\nUsing most recent filing matching query..."
+                f"{record}:\n{filing_meta}\n\nUsing most recent filing matching query..."  # noqa
             )
             self.stderr.write(msg)
 


### PR DESCRIPTION
This PR:

- Addresses duplicates in candidate and filing import
- Locks filings during transaction import to avoid collisions across parallel jobs
- Imports by month rather than quarter to reduce volume of data to import and therefore runtime
- Sets a max parallelis during import to keep traffic reasonable during import